### PR TITLE
chore: renaming package to `babylon-finality-gadget`

### DIFF
--- a/demo/main.go
+++ b/demo/main.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/babylonchain/babylon-da-sdk/btcclient"
-	"github.com/babylonchain/babylon-da-sdk/sdk"
+	"github.com/babylonchain/babylon-finality-gadget/btcclient"
+	"github.com/babylonchain/babylon-finality-gadget/sdk"
 )
 
 func checkBlockFinalized(height uint64, hash string) {
@@ -13,7 +13,7 @@ func checkBlockFinalized(height uint64, hash string) {
 		ChainType: 0,
 		// TODO: avoid using stub contract
 		ContractAddr: "bbn1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqxxvh0f",
-		BTCConfig: btcclient.DefaultBTCConfig(),
+		BTCConfig:    btcclient.DefaultBTCConfig(),
 	})
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/babylonchain/babylon-da-sdk
+module github.com/babylonchain/babylon-finality-gadget
 
 go 1.21
 

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -12,8 +12,8 @@ import (
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"go.uber.org/zap"
 
-	"github.com/babylonchain/babylon-da-sdk/btcclient"
-	"github.com/babylonchain/babylon-da-sdk/testutils"
+	"github.com/babylonchain/babylon-finality-gadget/btcclient"
+	"github.com/babylonchain/babylon-finality-gadget/testutils"
 )
 
 type BtcClient interface {

--- a/testutils/mock_btc_client.go
+++ b/testutils/mock_btc_client.go
@@ -1,7 +1,7 @@
 package testutils
 
 import (
-	"github.com/babylonchain/babylon-da-sdk/btcclient"
+	"github.com/babylonchain/babylon-finality-gadget/btcclient"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 )


### PR DESCRIPTION
Btw, when I do `make test` it shows below. Any ideas?

```
➜  babylon-finality-gadget git:(renaming) ✗ make test
go test ./sdk -v
=== RUN   TestQueryConsumerId
service injective.evm.v1beta1.Msg does not have cosmos.msg.v1.service proto annotation
--- FAIL: TestQueryConsumerId (0.03s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x2d50dcd]

goroutine 9 [running]:
testing.tRunner.func1.2({0x305f6e0, 0x5ec0af0})
        /usr/local/go/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1548 +0x397
panic({0x305f6e0?, 0x5ec0af0?})
        /usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/babylonchain/babylon-finality-gadget/btcclient.(*BTCConfig).ToConnConfig(...)
        /home/runchao/Projects/Babylon/babylon-finality-gadget/btcclient/config.go:53
github.com/babylonchain/babylon-finality-gadget/btcclient.NewBTCClient(0x0, 0xc0008922a0)
        /home/runchao/Projects/Babylon/babylon-finality-gadget/btcclient/client.go:20 +0x2d
github.com/babylonchain/babylon-finality-gadget/sdk.NewClient(0xc000d992a0)
        /home/runchao/Projects/Babylon/babylon-finality-gadget/sdk/client.go:91 +0x1fc
github.com/babylonchain/babylon-finality-gadget/sdk.newE2eClientWithStubContract()
        /home/runchao/Projects/Babylon/babylon-finality-gadget/sdk/sdk_test.go:22 +0x4f
github.com/babylonchain/babylon-finality-gadget/sdk.TestQueryConsumerId(0x0?)
        /home/runchao/Projects/Babylon/babylon-finality-gadget/sdk/sdk_test.go:30 +0x1c
testing.tRunner(0xc0013d5380, 0x39588d8)
        /usr/local/go/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1648 +0x3ad
FAIL    github.com/babylonchain/babylon-finality-gadget/sdk     0.133s
FAIL
make: *** [Makefile:5: test] Error 1
➜  babylon-finality-gadget git:(renaming) ✗ 
```