### PR TITLE
chore: expose QueryListOfVotedFinalityProviders in SDK

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -59,7 +59,7 @@ func createBlockVotersQueryData(queryParams *L2Block) ([]byte, error) {
 	return data, nil
 }
 
-func (babylonClient *BabylonFinalityGadgetClient) queryListOfVotedFinalityProviders(queryParams *L2Block) ([]string, error) {
+func (babylonClient *BabylonFinalityGadgetClient) QueryListOfVotedFinalityProviders(queryParams *L2Block) ([]string, error) {
 	queryData, err := createBlockVotersQueryData(queryParams)
 	if err != nil {
 		return nil, err
@@ -243,7 +243,7 @@ func (babylonClient *BabylonFinalityGadgetClient) QueryIsBlockBabylonFinalized(q
 	}
 
 	// get all FPs that voted this (L2 block height, L2 block hash) combination
-	votedFpPks, err := babylonClient.queryListOfVotedFinalityProviders(queryParams)
+	votedFpPks, err := babylonClient.QueryListOfVotedFinalityProviders(queryParams)
 	if err != nil {
 		return false, err
 	}

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -36,7 +36,7 @@ func TestQueryConsumerId(t *testing.T) {
 // this uses a stub contract deployed on Osmosis testnet
 // TODO: replace with one deployed on Babylon chain
 func queryListOfVotedFinalityProvidersHelper(client *BabylonFinalityGadgetClient, height uint64, hash string) ([]string, error) {
-	return client.queryListOfVotedFinalityProviders(&L2Block{
+	return client.QueryListOfVotedFinalityProviders(&L2Block{
 		BlockHeight:    height,
 		BlockHash:      hash,
 		BlockTimestamp: uint64(1718332131),


### PR DESCRIPTION
## Summary

we need to use the method in our e2e test [TestFinalityStuckAndRecover](https://github.com/babylonchain/finality-provider/blob/base/consumer-chain-support/itest/opstackl2/op_e2e_test.go#L140) to verify when FP votes, the vote does arrive in the cw contract.

this PR is part of the task: babylonchain/finality-provider#502


Since this method can also be useful for users and makes sense to be exposed as part of the SDK, I want to expose it instead of copying it to the FP e2e test.

## Test Plan

```
make lint
```
