### PR TITLE
feat: query finality for a block range

### DIFF
--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -2,4 +2,7 @@ package sdk
 
 import "fmt"
 
-var ErrNoFpHasVotingPower = fmt.Errorf("no FP has voting power for the consumer chain")
+var (
+	ErrNoFpHasVotingPower = fmt.Errorf("no FP has voting power for the consumer chain")
+	ErrEmptyQueryBlocks   = fmt.Errorf("query blocks is empty")
+)

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -4,5 +4,4 @@ import "fmt"
 
 var (
 	ErrNoFpHasVotingPower = fmt.Errorf("no FP has voting power for the consumer chain")
-	ErrEmptyQueryBlocks   = fmt.Errorf("query blocks is empty")
 )

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -197,6 +197,9 @@ func (babylonClient *BabylonFinalityGadgetClient) queryFpPower(fpPubkeyHex strin
 // QueryBlockRangeBabylonFinalized find the finalized block in the block range
 // if no block in the range is finalized, return nil
 // if yes, return the height of the last finalized block in the range
+// Note:
+// 1. make sure the given queryBlocks are consecutive and start from the lowest block
+// 2. the caller need to make sure the BlockHash in queryBlocks are consecutive
 func (babylonClient *BabylonFinalityGadgetClient) QueryBlockRangeBabylonFinalized(queryBlocks []*L2Block) (*uint64, error) {
 	if len(queryBlocks) == 0 {
 		return nil, fmt.Errorf("no blocks provided")

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -219,9 +219,6 @@ func (babylonClient *BabylonFinalityGadgetClient) QueryBlockRangeBabylonFinalize
 			break
 		}
 	}
-	if finalizedBlockHeight == nil {
-		return nil, fmt.Errorf("no block in the range is finalized")
-	}
 	return finalizedBlockHeight, nil
 }
 


### PR DESCRIPTION
This PR adds the function `QueryBlockRangeBabylonFinalized(queryBlocks []*L2Block)` that returns `uint64` representing the last finalized block in the block range.

This API will be used by the `tryFinalize()` in the OP finalizer. We found it doesn't call on each L2 block b/c `onPendingSafeUpdate` only triggered upon a new L1 block.