### PR TITLE
test: added more test cases for `QueryIsBlockBabylonFinalized`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
-	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.8.6-0.20240705135310-e91ff7f60ead
+	github.com/babylonchain/babylon => github.com/babylonchain/babylon-private v0.8.6-0.20240715110001-5cdf5bb3bbd9
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonchain/babylon-private v0.8.6-0.20240705135310-e91ff7f60ead h1:LyyrFtdSbx0a5ZLHA/qMNMjAxZltfnNJgj5+uEgqZdI=
-github.com/babylonchain/babylon-private v0.8.6-0.20240705135310-e91ff7f60ead/go.mod h1:Tdi+29Y+DzCaaz0V0sBRXF1tXXLnH6JHJsOG8uktWLU=
+github.com/babylonchain/babylon-private v0.8.6-0.20240715110001-5cdf5bb3bbd9 h1:cklI2EhkOy3oMJ58yL11C7KjcAl919EpoXBWr8sDlb4=
+github.com/babylonchain/babylon-private v0.8.6-0.20240715110001-5cdf5bb3bbd9/go.mod h1:eVovUiLvCvHRpXV7f8KzC4FND1UryaZmZc3bEdBvB8w=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/sdk/btcclient/client_test.go
+++ b/sdk/btcclient/client_test.go
@@ -7,14 +7,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestBtc is an e2e test to call into a stub CosmWasm contract deployed on Osmosis testnet
-// TODO: add more tests for some other edge cases
+// TODO: 1) not rely on mainnet RPC; 2) add more tests for some other edge cases
 func TestBtcClient(t *testing.T) {
 	var blockHeight uint64
 	var err error
 
 	// Create logger.
-	logger, err := zap.NewProduction()
+	logger, err := zap.NewDevelopment()
 	require.Nil(t, err)
 
 	// Create BTC client

--- a/sdk/client/query_test.go
+++ b/sdk/client/query_test.go
@@ -46,72 +46,72 @@ func TestQueryIsBlockBabylonFinalized(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		queryParams    cwclient.L2Block
-		fpPowers       map[string]uint64
+		expectedErr    error
+		queryParams    *cwclient.L2Block
 		allFpPks       []string
+		fpPowers       map[string]uint64
 		votedProviders []string
 		expectResult   bool
-		expectedErr    error
 	}{
 		{
 			name:           "0% votes, expects false",
-			queryParams:    blockWithHashTrimmed,
+			queryParams:    &blockWithHashTrimmed,
 			allFpPks:       []string{"pk1", "pk2"},
-			votedProviders: []string{},
 			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 300},
+			votedProviders: []string{},
 			expectResult:   false,
 			expectedErr:    nil,
 		},
 		{
 			name:           "25% votes, expects false",
-			queryParams:    blockWithHashTrimmed,
+			queryParams:    &blockWithHashTrimmed,
 			allFpPks:       []string{"pk1", "pk2"},
-			votedProviders: []string{"pk1"},
 			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 300},
+			votedProviders: []string{"pk1"},
 			expectResult:   false,
 			expectedErr:    nil,
 		},
 		{
 			name:           "exact 2/3 votes, expects true",
-			queryParams:    blockWithHashTrimmed,
+			queryParams:    &blockWithHashTrimmed,
 			allFpPks:       []string{"pk1", "pk2", "pk3"},
-			votedProviders: []string{"pk1", "pk2"},
 			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100},
+			votedProviders: []string{"pk1", "pk2"},
 			expectResult:   true,
 			expectedErr:    nil,
 		},
 		{
 			name:           "75% votes, expects true",
-			queryParams:    blockWithHashTrimmed,
+			queryParams:    &blockWithHashTrimmed,
 			allFpPks:       []string{"pk1", "pk2"},
-			votedProviders: []string{"pk2"},
 			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 300},
+			votedProviders: []string{"pk2"},
 			expectResult:   true,
 			expectedErr:    nil,
 		},
 		{
 			name:           "100% votes, expects true",
-			queryParams:    blockWithHashTrimmed,
+			queryParams:    &blockWithHashTrimmed,
 			allFpPks:       []string{"pk1", "pk2", "pk3"},
-			votedProviders: []string{"pk1", "pk2", "pk3"},
 			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100},
+			votedProviders: []string{"pk1", "pk2", "pk3"},
 			expectResult:   true,
 			expectedErr:    nil,
 		},
 		{
 			name:           "untrimmed block hash in input params, 75% votes, expects true",
-			queryParams:    blockWithHashUntrimmed,
+			queryParams:    &blockWithHashUntrimmed,
 			allFpPks:       []string{"pk1", "pk2", "pk3", "pk4"},
-			votedProviders: []string{"pk1", "pk2", "pk3"},
 			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100, "pk4": 100},
+			votedProviders: []string{"pk1", "pk2", "pk3"},
 			expectResult:   true,
 		},
 		{
 			name:           "zero voting power, 100% votes, expects false",
-			queryParams:    blockWithHashUntrimmed,
+			queryParams:    &blockWithHashUntrimmed,
 			allFpPks:       []string{"pk1", "pk2", "pk3"},
-			votedProviders: []string{"pk1", "pk2", "pk3"},
 			fpPowers:       map[string]uint64{"pk1": 0, "pk2": 0, "pk3": 0},
+			votedProviders: []string{"pk1", "pk2", "pk3"},
 			expectResult:   false,
 			expectedErr:    ErrNoFpHasVotingPower,
 		},
@@ -154,7 +154,7 @@ func TestQueryIsBlockBabylonFinalized(t *testing.T) {
 				btcClient: mockBTCClient,
 			}
 
-			res, err := mockSdkClient.QueryIsBlockBabylonFinalized(tc.queryParams)
+			res, err := mockSdkClient.QueryIsBlockBabylonFinalized(*tc.queryParams)
 			require.Equal(t, tc.expectResult, res)
 			require.Equal(t, tc.expectedErr, err)
 		})

--- a/sdk/client/query_test.go
+++ b/sdk/client/query_test.go
@@ -28,6 +28,31 @@ func TestFinalityGadgetDisabled(t *testing.T) {
 	require.True(t, res)
 }
 
+// func TestTrimHash(t *testing.T) {
+// 	ctl := gomock.NewController(t)
+
+// 	queryParams := cwclient.L2Block{
+// 		BlockHash:      "0x123",
+// 		BlockHeight:    123,
+// 		BlockTimestamp: 12345,
+// 	}
+
+// 	// mock CwClient
+// 	mockCwClient := mocks.NewMockICosmWasmClient(ctl)
+// 	mockCwClient.EXPECT().QueryIsEnabled().Return(false, nil).Times(1)
+
+// 	mockSdkClient := &SdkClient{
+// 		cwClient:  mockCwClient,
+// 		bbnClient: nil,
+// 		btcClient: nil,
+// 	}
+
+// 	// check QueryIsBlockBabylonFinalized always returns true when finality gadget is not enabled
+// 	res, err := mockSdkClient.QueryIsBlockBabylonFinalized(cwclient.L2Block{})
+// 	require.NoError(t, err)
+// 	require.True(t, res)
+// }
+
 func TestQueryIsBlockBabylonFinalized(t *testing.T) {
 	queryParams := cwclient.L2Block{
 		BlockHash:      "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",

--- a/sdk/client/query_test.go
+++ b/sdk/client/query_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/babylonchain/babylon-finality-gadget/sdk/cwclient"
@@ -29,17 +30,14 @@ func TestFinalityGadgetDisabled(t *testing.T) {
 }
 
 func TestQueryIsBlockBabylonFinalized(t *testing.T) {
-	blockWithHashTrimmed := cwclient.L2Block{
-		BlockHash:      "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
-		BlockHeight:    123,
-		BlockTimestamp: 12345,
-	}
-
 	blockWithHashUntrimmed := cwclient.L2Block{
 		BlockHash:      "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
 		BlockHeight:    123,
 		BlockTimestamp: 12345,
 	}
+
+	blockWithHashTrimmed := blockWithHashUntrimmed
+	blockWithHashTrimmed.BlockHash = strings.TrimPrefix(blockWithHashUntrimmed.BlockHash, "0x")
 
 	const consumerChainID = "consumer-chain-id"
 	const BTCHeight = uint64(111)

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -34,7 +34,6 @@ func (config *Config) getDefaultRpcAddr() (string, error) {
 		return "http://127.0.0.1:26657", nil
 	case "euphrates-0.2.0":
 		return "https://rpc-euphrates.devnet.babylonchain.io/", nil
-	// TODO: replace with babylon RPCs when QuerySmartContractStateRequest query is supported
 	// TODO: add mainnet RPCs when available
 	default:
 		return "", fmt.Errorf("unrecognized chain id: %s", config.ChainID)

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -29,10 +29,10 @@ func (config *Config) GetRpcAddr() (string, error) {
 
 func (config *Config) getDefaultRpcAddr() (string, error) {
 	switch config.ChainID {
-	case "chain-test":
+	case BabylonLocalnet:
 		// for the e2e test
 		return "http://127.0.0.1:26657", nil
-	case "euphrates-0.2.0":
+	case BabylonDevnet:
 		return "https://rpc-euphrates.devnet.babylonchain.io/", nil
 	// TODO: add mainnet RPCs when available
 	default:


### PR DESCRIPTION
## Summary

This complements #56 and adds a few more test cases:
- 0% votes
- 100% votes
- untrimmed block hash in input params
- zero voting power for all FPs

## Test Plan

```
make lint
make test
```