### PR TITLE
test: added test cases for `QueryBlockRangeBabylonFinalized`

### DIFF
--- a/sdk/client/query.go
+++ b/sdk/client/query.go
@@ -127,7 +127,7 @@ func (sdkClient *SdkClient) QueryBlockRangeBabylonFinalized(
 	for _, block := range queryBlocks {
 		isFinalized, err := sdkClient.QueryIsBlockBabylonFinalized(*block)
 		if err != nil {
-			return nil, err
+			return finalizedBlockHeight, err
 		}
 		if isFinalized {
 			finalizedBlockHeight = &block.BlockHeight

--- a/sdk/client/query_test.go
+++ b/sdk/client/query_test.go
@@ -185,7 +185,7 @@ func TestQueryBlockRangeBabylonFinalized(t *testing.T) {
 		{"single block with finalized", nil, &blockA.BlockHeight, []*cwclient.L2Block{&blockA}},
 		{"single block with error", fmt.Errorf("RPC rate limit error"), nil, []*cwclient.L2Block{&blockD}},
 		{"non-consecutive blocks", fmt.Errorf("blocks are not consecutive"), nil, []*cwclient.L2Block{&blockA, &blockD}},
-		{"consecutive blocks that are partially finalized", nil, &blockB.BlockHeight, []*cwclient.L2Block{&blockA, &blockB, &blockC}},
+		{"partially blocks are finalized and the last block has error", fmt.Errorf("RPC rate limit error"), &blockB.BlockHeight, []*cwclient.L2Block{&blockA, &blockB, &blockC}},
 		{"all consecutive blocks are finalized", nil, &blockB.BlockHeight, []*cwclient.L2Block{&blockA, &blockB}},
 		{"none of the block is finalized and the first block has error", fmt.Errorf("RPC rate limit error"), nil, []*cwclient.L2Block{&blockD, &blockE}},
 		{"none of the block is finalized and the second block has error", nil, nil, []*cwclient.L2Block{&blockF, &blockG}},
@@ -209,7 +209,7 @@ func TestQueryBlockRangeBabylonFinalized(t *testing.T) {
 			mockCwClient.EXPECT().QueryConsumerId().Return("consumer-chain-id", nil).AnyTimes()
 			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockAWithHashTrimmed).Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
 			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockBWithHashTrimmed).Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
-			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockCWithHashTrimmed).Return([]string{"pk1"}, nil).AnyTimes()
+			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockCWithHashTrimmed).Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
 			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockDWithHashTrimmed).Return([]string{"pk3"}, nil).AnyTimes()
 			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockEWithHashTrimmed).Return([]string{"pk1"}, nil).AnyTimes()
 			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockFWithHashTrimmed).Return([]string{"pk2"}, nil).AnyTimes()
@@ -217,7 +217,7 @@ func TestQueryBlockRangeBabylonFinalized(t *testing.T) {
 
 			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockA.BlockTimestamp).Return(uint64(111), nil).AnyTimes()
 			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockB.BlockTimestamp).Return(uint64(111), nil).AnyTimes()
-			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockC.BlockTimestamp).Return(uint64(111), nil).AnyTimes()
+			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockC.BlockTimestamp).Return(uint64(111), fmt.Errorf("RPC rate limit error")).AnyTimes()
 			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockD.BlockTimestamp).Return(uint64(112), fmt.Errorf("RPC rate limit error")).AnyTimes()
 			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockE.BlockTimestamp).Return(uint64(112), nil).AnyTimes()
 			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockF.BlockTimestamp).Return(uint64(113), nil).AnyTimes()

--- a/sdk/client/query_test.go
+++ b/sdk/client/query_test.go
@@ -1,11 +1,14 @@
 package client
 
 import (
+	"fmt"
+	"math/rand"
 	"strings"
 	"testing"
 
 	"github.com/babylonchain/babylon-finality-gadget/sdk/cwclient"
 	"github.com/babylonchain/babylon-finality-gadget/testutil/mocks"
+	"github.com/babylonchain/babylon-finality-gadget/testutils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -153,6 +156,110 @@ func TestQueryIsBlockBabylonFinalized(t *testing.T) {
 			}
 
 			res, err := mockSdkClient.QueryIsBlockBabylonFinalized(*tc.queryParams)
+			require.Equal(t, tc.expectResult, res)
+			require.Equal(t, tc.expectedErr, err)
+		})
+	}
+}
+
+func TestQueryBlockRangeBabylonFinalized(t *testing.T) {
+	rng := rand.New(rand.NewSource(1234))
+
+	l2BlockTime := uint64(2)
+	blockA := testutils.RandomL2Block(rng)
+	blockAWithHashTrimmed := blockA
+	blockAWithHashTrimmed.BlockHash = strings.TrimPrefix(blockA.BlockHash, "0x")
+
+	blockB := cwclient.L2Block{
+		BlockHash:      testutils.RandomHash(rng).String(),
+		BlockHeight:    blockA.BlockHeight + 1,
+		BlockTimestamp: blockA.BlockTimestamp + l2BlockTime,
+	}
+	blockBWithHashTrimmed := blockB
+	blockBWithHashTrimmed.BlockHash = strings.TrimPrefix(blockB.BlockHash, "0x")
+
+	blockC := cwclient.L2Block{
+		BlockHash:      testutils.RandomHash(rng).String(),
+		BlockHeight:    blockB.BlockHeight + 1,
+		BlockTimestamp: blockB.BlockTimestamp + l2BlockTime,
+	}
+	blockCWithHashTrimmed := blockC
+	blockCWithHashTrimmed.BlockHash = strings.TrimPrefix(blockC.BlockHash, "0x")
+
+	blockD := cwclient.L2Block{
+		BlockHash:      testutils.RandomHash(rng).String(),
+		BlockHeight:    blockC.BlockHeight + 1,
+		BlockTimestamp: blockC.BlockTimestamp + l2BlockTime,
+	}
+	blockDWithHashTrimmed := blockD
+	blockDWithHashTrimmed.BlockHash = strings.TrimPrefix(blockD.BlockHash, "0x")
+
+	blockE := cwclient.L2Block{
+		BlockHash:      testutils.RandomHash(rng).String(),
+		BlockHeight:    blockD.BlockHeight + 300,
+		BlockTimestamp: blockD.BlockTimestamp + 300*l2BlockTime, // 10 minutes later
+	}
+	blockEWithHashTrimmed := blockE
+	blockEWithHashTrimmed.BlockHash = strings.TrimPrefix(blockE.BlockHash, "0x")
+
+	blockF := cwclient.L2Block{
+		BlockHash:      testutils.RandomHash(rng).String(),
+		BlockHeight:    blockE.BlockHeight + 1,
+		BlockTimestamp: blockE.BlockTimestamp + l2BlockTime,
+	}
+	blockFWithHashTrimmed := blockF
+	blockFWithHashTrimmed.BlockHash = strings.TrimPrefix(blockF.BlockHash, "0x")
+
+	testCases := []struct {
+		name         string
+		queryBlocks  []*cwclient.L2Block
+		expectResult *uint64
+		expectedErr  error
+	}{
+		{"empty query blocks", []*cwclient.L2Block{}, nil, fmt.Errorf("no blocks provided")},
+		{"single block with finalized", []*cwclient.L2Block{&blockA}, &blockA.BlockHeight, nil},
+		{"single block with error", []*cwclient.L2Block{&blockE}, nil, ErrNoFpHasVotingPower},
+		{"non-consecutive blocks", []*cwclient.L2Block{&blockA, &blockE}, nil, fmt.Errorf("blocks are not consecutive")},
+		{"consecutive blocks with finalized partially", []*cwclient.L2Block{&blockA, &blockB, &blockC, &blockD}, &blockC.BlockHeight, nil},
+		{"all blocks with finalized", []*cwclient.L2Block{&blockA, &blockB, &blockC}, &blockC.BlockHeight, nil},
+		{"consecutive blocks with error", []*cwclient.L2Block{&blockE, &blockF}, nil, ErrNoFpHasVotingPower},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctl := gomock.NewController(t)
+			defer ctl.Finish()
+
+			mockCwClient := mocks.NewMockICosmWasmClient(ctl)
+			mockBTCClient := mocks.NewMockIBitcoinClient(ctl)
+			mockBBNClient := mocks.NewMockIBabylonClient(ctl)
+			mockSdkClient := &SdkClient{
+				cwClient:  mockCwClient,
+				bbnClient: mockBBNClient,
+				btcClient: mockBTCClient,
+			}
+
+			mockCwClient.EXPECT().QueryIsEnabled().Return(true, nil).AnyTimes()
+			mockCwClient.EXPECT().QueryConsumerId().Return("consumer-chain-id", nil).AnyTimes()
+			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockAWithHashTrimmed).Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
+			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockBWithHashTrimmed).Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
+			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockCWithHashTrimmed).Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
+			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockDWithHashTrimmed).Return([]string{"pk1"}, nil).AnyTimes()
+			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockEWithHashTrimmed).Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
+			mockCwClient.EXPECT().QueryListOfVotedFinalityProviders(&blockFWithHashTrimmed).Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
+
+			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockA.BlockTimestamp).Return(uint64(111), nil).AnyTimes()
+			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockB.BlockTimestamp).Return(uint64(111), nil).AnyTimes()
+			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockC.BlockTimestamp).Return(uint64(111), nil).AnyTimes()
+			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockD.BlockTimestamp).Return(uint64(111), nil).AnyTimes()
+			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockE.BlockTimestamp).Return(uint64(112), nil).AnyTimes()
+			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockF.BlockTimestamp).Return(uint64(112), nil).AnyTimes()
+
+			mockBBNClient.EXPECT().QueryAllFpBtcPubKeys("consumer-chain-id").Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
+			mockBBNClient.EXPECT().QueryMultiFpPower([]string{"pk1", "pk2", "pk3"}, uint64(111)).Return(map[string]uint64{"pk1": 100, "pk2": 300, "pk3": 0}, nil).AnyTimes()
+			mockBBNClient.EXPECT().QueryMultiFpPower([]string{"pk1", "pk2", "pk3"}, uint64(112)).Return(map[string]uint64{"pk1": 0, "pk2": 0, "pk3": 0}, nil).AnyTimes()
+
+			res, err := mockSdkClient.QueryBlockRangeBabylonFinalized(tc.queryBlocks)
 			require.Equal(t, tc.expectResult, res)
 			require.Equal(t, tc.expectedErr, err)
 		})

--- a/sdk/client/query_test.go
+++ b/sdk/client/query_test.go
@@ -185,7 +185,7 @@ func TestQueryBlockRangeBabylonFinalized(t *testing.T) {
 		{"single block with finalized", nil, &blockA.BlockHeight, []*cwclient.L2Block{&blockA}},
 		{"single block with error", fmt.Errorf("RPC rate limit error"), nil, []*cwclient.L2Block{&blockD}},
 		{"non-consecutive blocks", fmt.Errorf("blocks are not consecutive"), nil, []*cwclient.L2Block{&blockA, &blockD}},
-		{"partially blocks are finalized and the last block has error", fmt.Errorf("RPC rate limit error"), &blockB.BlockHeight, []*cwclient.L2Block{&blockA, &blockB, &blockC}},
+		{"the first two blocks are finalized and the last block has error", fmt.Errorf("RPC rate limit error"), &blockB.BlockHeight, []*cwclient.L2Block{&blockA, &blockB, &blockC}},
 		{"all consecutive blocks are finalized", nil, &blockB.BlockHeight, []*cwclient.L2Block{&blockA, &blockB}},
 		{"none of the block is finalized and the first block has error", fmt.Errorf("RPC rate limit error"), nil, []*cwclient.L2Block{&blockD, &blockE}},
 		{"none of the block is finalized and the second block has error", nil, nil, []*cwclient.L2Block{&blockF, &blockG}},

--- a/sdk/client/query_test.go
+++ b/sdk/client/query_test.go
@@ -212,17 +212,17 @@ func TestQueryBlockRangeBabylonFinalized(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		queryBlocks  []*cwclient.L2Block
-		expectResult *uint64
 		expectedErr  error
+		expectResult *uint64
+		queryBlocks  []*cwclient.L2Block
 	}{
-		{"empty query blocks", []*cwclient.L2Block{}, nil, fmt.Errorf("no blocks provided")},
-		{"single block with finalized", []*cwclient.L2Block{&blockA}, &blockA.BlockHeight, nil},
-		{"single block with error", []*cwclient.L2Block{&blockE}, nil, ErrNoFpHasVotingPower},
-		{"non-consecutive blocks", []*cwclient.L2Block{&blockA, &blockE}, nil, fmt.Errorf("blocks are not consecutive")},
-		{"consecutive blocks with finalized partially", []*cwclient.L2Block{&blockA, &blockB, &blockC, &blockD}, &blockC.BlockHeight, nil},
-		{"all blocks with finalized", []*cwclient.L2Block{&blockA, &blockB, &blockC}, &blockC.BlockHeight, nil},
-		{"consecutive blocks with error", []*cwclient.L2Block{&blockE, &blockF}, nil, ErrNoFpHasVotingPower},
+		{"empty query blocks", fmt.Errorf("no blocks provided"), nil, []*cwclient.L2Block{}},
+		{"single block with finalized", nil, &blockA.BlockHeight, []*cwclient.L2Block{&blockA}},
+		{"single block with error", ErrNoFpHasVotingPower, nil, []*cwclient.L2Block{&blockE}},
+		{"non-consecutive blocks", fmt.Errorf("blocks are not consecutive"), nil, []*cwclient.L2Block{&blockA, &blockE}},
+		{"consecutive blocks with finalized partially", nil, &blockC.BlockHeight, []*cwclient.L2Block{&blockA, &blockB, &blockC, &blockD}},
+		{"all blocks with finalized", nil, &blockC.BlockHeight, []*cwclient.L2Block{&blockA, &blockB, &blockC}},
+		{"consecutive blocks with error", ErrNoFpHasVotingPower, nil, []*cwclient.L2Block{&blockE, &blockF}},
 	}
 
 	for _, tc := range testCases {

--- a/testutils/random.go
+++ b/testutils/random.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"math/rand"
+	"strings"
 
 	"github.com/babylonchain/babylon-finality-gadget/sdk/cwclient"
 	"github.com/ethereum/go-ethereum/common"
@@ -12,9 +13,20 @@ func RandomHash(rng *rand.Rand) (out common.Hash) {
 	return
 }
 
-func RandomL2Block(rng *rand.Rand) (out cwclient.L2Block) {
+func RandomL2Block(rng *rand.Rand) (out cwclient.L2Block, outWithHashTrimmed cwclient.L2Block) {
 	out.BlockHash = RandomHash(rng).String()
 	out.BlockHeight = rng.Uint64()
 	out.BlockTimestamp = rng.Uint64()
+	outWithHashTrimmed = out
+	outWithHashTrimmed.BlockHash = strings.TrimPrefix(out.BlockHash, "0x")
+	return
+}
+
+func GenL2Block(rng *rand.Rand, initBlock *cwclient.L2Block, l2BlockTime uint64, offset uint64) (out cwclient.L2Block, outWithHashTrimmed cwclient.L2Block) {
+	out.BlockHash = RandomHash(rng).String()
+	out.BlockHeight = initBlock.BlockHeight + offset
+	out.BlockTimestamp = initBlock.BlockTimestamp + offset*l2BlockTime
+	outWithHashTrimmed = out
+	outWithHashTrimmed.BlockHash = strings.TrimPrefix(out.BlockHash, "0x")
 	return
 }

--- a/testutils/random.go
+++ b/testutils/random.go
@@ -1,0 +1,20 @@
+package testutils
+
+import (
+	"math/rand"
+
+	"github.com/babylonchain/babylon-finality-gadget/sdk/cwclient"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func RandomHash(rng *rand.Rand) (out common.Hash) {
+	rng.Read(out[:])
+	return
+}
+
+func RandomL2Block(rng *rand.Rand) (out cwclient.L2Block) {
+	out.BlockHash = RandomHash(rng).String()
+	out.BlockHeight = rng.Uint64()
+	out.BlockTimestamp = rng.Uint64()
+	return
+}


### PR DESCRIPTION
## Summary

This PR adds some test cases for `QueryBlockRangeBabylonFinalized`:

* empty query blocks
* single block with finalized
* single block with error
* non-consecutive blocks
* partially blocks are finalized and the last block has error
* all consecutive blocks are finalized
* none of the block is finalized and the first block has error
* none of the block is finalized and the second block has error

## Test Plan

```
make lint
make test
```