### PR TITLE
feat: add query for btc staking activated timestamp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ jobs:
           command: |
             make test
 
-workflows:
-  CI:
-    jobs:
+# workflows:
+#   CI:
+#     jobs:
       # TODO:
       # 1) enable this job after migrating to https://github.com/babylonlabs-io
       # 2) fix the ssh secrets for accessing babylon-private

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,4 +39,7 @@ jobs:
 workflows:
   CI:
     jobs:
-      - build_lint_test
+      # TODO:
+      # 1) enable this job after migrating to https://github.com/babylonlabs-io
+      # 2) fix the ssh secrets for accessing babylon-private
+      # - build_lint_test

--- a/sdk/bbnclient/bbnclient.go
+++ b/sdk/bbnclient/bbnclient.go
@@ -149,7 +149,7 @@ func (bbnClient *Client) QueryFpEarliestActiveDelBtcHeight(fpPubkeyHex string) (
 // 1) the staking tx is k-deep in Bitcoin, i.e., start_height + k
 // 2) it receives a quorum number of covenant committee signatures
 func isActiveBtcDelegation(btcDel *types.BTCDelegationResponse, latestBtcHeight, confirmationHeight uint64, covQuorum uint32) bool {
-	return latestBtcHeight > confirmationHeight &&
+	return latestBtcHeight >= confirmationHeight &&
 		btcDel.EndHeight > confirmationHeight &&
-		uint32(len(btcDel.CovenantSigs)) > covQuorum
+		uint32(len(btcDel.CovenantSigs)) >= covQuorum
 }

--- a/sdk/bbnclient/query_internal.go
+++ b/sdk/bbnclient/query_internal.go
@@ -25,6 +25,17 @@ func (bbnClient *Client) isDelegationActive(
 		return false, nil
 	}
 
+	// k is not involved in the `GetStatus` logic as Babylon will accept a BTC delegation request
+	// only when staking tx is k-deep on BTC.
+	//
+	// But the msg handler performs both checks 1) ensure staking tx is k-deep, and 2) ensure the
+	// staking tx's timelock has at least w BTC blocks left.
+	// (https://github.com/babylonchain/babylon-private/blob/d64ddc97d1c8b9f695b814b7b1b92ce133f2547b/x/btcstaking/keeper/msg_server.go#L266-L278)
+	//
+	// So after the msg handler accepts BTC delegation the 1st check is no longer needed
+	// the k-value check is added per
+	//
+	// So in our case, we need to check both to ensure the delegation is active
 	if btcHeight < btcDel.StartHeight+kValue || btcHeight+wValue > btcDel.EndHeight {
 		return false, nil
 	}

--- a/sdk/bbnclient/query_internal.go
+++ b/sdk/bbnclient/query_internal.go
@@ -2,8 +2,8 @@ package bbnclient
 
 import btcstakingtypes "github.com/babylonchain/babylon/x/btcstaking/types"
 
-// we implemented exact logic as in
-// https://github.com/babylonchain/babylon-private/blob/c5a8d317091e2965e20ea56fa10e98d34aaa3547/x/btcstaking/types/btc_delegation.go#L111-L119
+// we implemented exact logic as in GetStatus
+// https://github.com/babylonchain/babylon-private/blob/c5a8d317091e2965e20ea56fa10e98d34aaa3547/x/btcstaking/types/btc_delegation.go#L88-L109
 func (bbnClient *Client) isDelegationActive(
 	btcDel *btcstakingtypes.BTCDelegationResponse,
 	btcHeight uint64,

--- a/sdk/bbnclient/query_internal.go
+++ b/sdk/bbnclient/query_internal.go
@@ -16,6 +16,7 @@ func (bbnClient *Client) isDelegationActive(
 	if err != nil {
 		return false, err
 	}
+	kValue := btccheckpointParams.GetParams().BtcConfirmationDepth
 	wValue := btccheckpointParams.GetParams().CheckpointFinalizationTimeout
 	covQuorum := btcstakingParams.GetParams().CovenantQuorum
 	ud := btcDel.UndelegationResponse
@@ -24,7 +25,7 @@ func (bbnClient *Client) isDelegationActive(
 		return false, nil
 	}
 
-	if btcHeight < btcDel.StartHeight || btcHeight+wValue > btcDel.EndHeight {
+	if btcHeight < btcDel.StartHeight+kValue || btcHeight+wValue > btcDel.EndHeight {
 		return false, nil
 	}
 

--- a/sdk/btcclient/client.go
+++ b/sdk/btcclient/client.go
@@ -90,19 +90,10 @@ func (c *BTCClient) GetBlockHeightByTimestamp(targetTimestamp uint64) (uint64, e
 	for lowerBound <= upperBound {
 		midHeight := (lowerBound + upperBound) / 2
 
-		// get block hash by height
-		blockHash, err := c.GetBlockHashByHeight(midHeight)
+		blockTimestamp, err := c.GetBlockTimestampByHeight(midHeight)
 		if err != nil {
 			return 0, err
 		}
-
-		// get block header by hash. the header contains info such as the block time expressed in UNIX epoch time
-		blockHeader, err := c.GetBlockHeaderByHash(blockHash)
-		if err != nil {
-			return 0, err
-		}
-
-		blockTimestamp := uint64(blockHeader.Timestamp.Unix())
 
 		if blockTimestamp < targetTimestamp {
 			lowerBound = midHeight + 1

--- a/sdk/btcclient/client.go
+++ b/sdk/btcclient/client.go
@@ -122,6 +122,22 @@ func (c *BTCClient) GetBlockHeightByTimestamp(targetTimestamp uint64) (uint64, e
 	return lowerBound - 1, nil
 }
 
+func (c *BTCClient) GetBlockTimestampByHeight(height uint64) (uint64, error) {
+	// get block hash by height
+	blockHash, err := c.GetBlockHashByHeight(height)
+	if err != nil {
+		return 0, err
+	}
+
+	// get block header by hash. the header contains info such as the block time expressed in UNIX epoch time
+	blockHeader, err := c.GetBlockHeaderByHash(blockHash)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(blockHeader.Timestamp.Unix()), nil
+}
+
 func clientCallWithRetry[T any](
 	call retry.RetryableFuncWithData[*T], logger *zap.Logger, cfg *BTCConfig,
 ) (*T, error) {

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -3,13 +3,13 @@ package client
 import (
 	"fmt"
 
-	"github.com/babylonchain/babylon-finality-gadget/testutils"
 	bbncfg "github.com/babylonchain/babylon/client/config"
 	"go.uber.org/zap"
 
 	"github.com/babylonchain/babylon-finality-gadget/sdk/bbnclient"
 	"github.com/babylonchain/babylon-finality-gadget/sdk/btcclient"
 	sdkconfig "github.com/babylonchain/babylon-finality-gadget/sdk/config"
+	"github.com/babylonchain/babylon-finality-gadget/testutil"
 
 	babylonClient "github.com/babylonchain/babylon/client/client"
 
@@ -55,7 +55,7 @@ func NewClient(config *sdkconfig.Config) (*SdkClient, error) {
 	switch config.ChainID {
 	// TODO: once we set up our own local BTC devnet, we don't need to use this mock BTC client
 	case sdkconfig.BabylonLocalnet:
-		btcClient, err = testutils.NewMockBTCClient(config.BTCConfig, logger)
+		btcClient, err = testutil.NewMockBTCClient(config.BTCConfig, logger)
 	default:
 		btcClient, err = btcclient.NewBTCClient(config.BTCConfig, logger)
 	}

--- a/sdk/client/expected_clients.go
+++ b/sdk/client/expected_clients.go
@@ -10,7 +10,7 @@ type IBabylonClient interface {
 	QueryAllFpBtcPubKeys(consumerId string) ([]string, error)
 	QueryFpPower(fpPubkeyHex string, btcHeight uint64) (uint64, error)
 	QueryMultiFpPower(fpPubkeyHexList []string, btcHeight uint64) (map[string]uint64, error)
-	QueryEarliestActiveDelBtcHeight(fpPubkeyHexList []string) (*uint64, error)
+	QueryEarliestActiveDelBtcHeight(fpPubkeyHexList []string) (uint64, error)
 }
 
 type IBitcoinClient interface {
@@ -18,6 +18,7 @@ type IBitcoinClient interface {
 	GetBlockHashByHeight(height uint64) (*chainhash.Hash, error)
 	GetBlockHeaderByHash(blockHash *chainhash.Hash) (*wire.BlockHeader, error)
 	GetBlockHeightByTimestamp(targetTimestamp uint64) (uint64, error)
+	GetBlockTimestampByHeight(height uint64) (uint64, error)
 }
 
 type ICosmWasmClient interface {

--- a/sdk/client/interface.go
+++ b/sdk/client/interface.go
@@ -37,5 +37,9 @@ type ISdkClient interface {
 	 */
 	QueryBlockRangeBabylonFinalized(queryBlocks []*cwclient.L2Block) (*uint64, error)
 
-	QueryEarliestDelHeight() (*uint64, error)
+	/* QueryBtcStakingActivatedTimestamp returns the timestamp when the BTC staking is activated
+	 *
+	 * returns ErrBtcStakingNotActivated if the BTC staking is not activated
+	 */
+	QueryBtcStakingActivatedTimestamp() (uint64, error)
 }

--- a/sdk/client/interface.go
+++ b/sdk/client/interface.go
@@ -39,7 +39,7 @@ type ISdkClient interface {
 
 	/* QueryBtcStakingActivatedTimestamp returns the timestamp when the BTC staking is activated
 	 *
-	 * returns ErrBtcStakingNotActivated if the BTC staking is not activated
+	 * returns math.MaxUint64, ErrBtcStakingNotActivated if the BTC staking is not activated
 	 */
 	QueryBtcStakingActivatedTimestamp() (uint64, error)
 }

--- a/sdk/client/interface.go
+++ b/sdk/client/interface.go
@@ -39,6 +39,18 @@ type ISdkClient interface {
 
 	/* QueryBtcStakingActivatedTimestamp returns the timestamp when the BTC staking is activated
 	 *
+	 * - We will check for k deep and covenant quorum to mark a delegation as active
+	 * - So technically, activated time needs to be max of the following
+	 *	 - timestamp of Babylon block that BTC delegation receives covenant quorum
+	 *	 - timestamp of BTC block that BTC delegation's staking tx becomes k-deep
+	 * - But we don't have a Babylon API to find the earliest Babylon block where BTC delegation gets covenant quorum.
+	 *   and it's probably not a good idea to add this to Babylon, as this creates more coupling between Babylon and
+	 *   consumer. So waiting for covenant quorum can be implemented in a clean way only with Babylon side support.
+	 *   This will be considered as future work
+	 * - For now, we will use the k-deep BTC block timestamp for the activation timestamp
+	 * - The time diff issue is not burning. The time diff between pending and active only matters if FP equivocates
+	 *   during that time period
+	 *
 	 * returns math.MaxUint64, ErrBtcStakingNotActivated if the BTC staking is not activated
 	 */
 	QueryBtcStakingActivatedTimestamp() (uint64, error)

--- a/sdk/client/query.go
+++ b/sdk/client/query.go
@@ -57,7 +57,7 @@ func (sdkClient *SdkClient) QueryIsBlockBabylonFinalized(
 	if err != nil {
 		return false, err
 	}
-	if earliestDelHeight == math.MaxUint64 || btcblockHeight < earliestDelHeight {
+	if btcblockHeight < earliestDelHeight {
 		return false, ErrBtcStakingNotActivated
 	}
 

--- a/sdk/client/query.go
+++ b/sdk/client/query.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/babylonchain/babylon-finality-gadget/sdk/cwclient"
@@ -161,7 +162,7 @@ func (sdkClient *SdkClient) QueryBtcStakingActivatedTimestamp() (uint64, error) 
 
 	// not activated yet
 	if earliestDelHeight == 0 {
-		return 0, ErrBtcStakingNotActivated
+		return math.MaxUint64, ErrBtcStakingNotActivated
 	}
 
 	// get the timestamp of the BTC height

--- a/sdk/client/query.go
+++ b/sdk/client/query.go
@@ -151,13 +151,13 @@ func (sdkClient *SdkClient) QueryBlockRangeBabylonFinalized(
 func (sdkClient *SdkClient) QueryBtcStakingActivatedTimestamp() (uint64, error) {
 	allFpPks, err := sdkClient.queryAllFpBtcPubKeys()
 	if err != nil {
-		return 0, err
+		return math.MaxUint64, err
 	}
 
 	// check whether the btc staking is actived
 	earliestDelHeight, err := sdkClient.bbnClient.QueryEarliestActiveDelBtcHeight(allFpPks)
 	if err != nil {
-		return 0, err
+		return math.MaxUint64, err
 	}
 
 	// not activated yet
@@ -168,7 +168,7 @@ func (sdkClient *SdkClient) QueryBtcStakingActivatedTimestamp() (uint64, error) 
 	// get the timestamp of the BTC height
 	btcBlockTimestamp, err := sdkClient.btcClient.GetBlockTimestampByHeight(earliestDelHeight)
 	if err != nil {
-		return 0, err
+		return math.MaxUint64, err
 	}
 	return btcBlockTimestamp, nil
 }

--- a/sdk/client/query.go
+++ b/sdk/client/query.go
@@ -144,9 +144,19 @@ func (sdkClient *SdkClient) QueryBlockRangeBabylonFinalized(
 
 /* QueryBtcStakingActivatedTimestamp returns the timestamp when the BTC staking is activated
  *
- * - get all FPs pubkey for the consumer chain
- * - get the BTC staking activation height
- * - get the timestamp of the BTC staking activation height
+ * - We will check for k deep and covenant quorum to mark a delegation as active
+ * - So technically, activated time needs to be max of the following
+ *	 - timestamp of Babylon block that BTC delegation receives covenant quorum
+ *	 - timestamp of BTC block that BTC delegation's staking tx becomes k-deep
+ * - But we don't have a Babylon API to find the earliest Babylon block where BTC delegation gets covenant quorum.
+ *   and it's probably not a good idea to add this to Babylon, as this creates more coupling between Babylon and
+ *   consumer. So waiting for covenant quorum can be implemented in a clean way only with Babylon side support.
+ *   this will be considered as future work
+ * - For now, we will use the k-deep BTC block timestamp for the activation timestamp
+ * - The time diff issue is not burning. The time diff between pending and active only matters if FP equivocates
+ *   during that time period
+ *
+ * returns math.MaxUint64, ErrBtcStakingNotActivated if the BTC staking is not activated
  */
 func (sdkClient *SdkClient) QueryBtcStakingActivatedTimestamp() (uint64, error) {
 	allFpPks, err := sdkClient.queryAllFpBtcPubKeys()

--- a/sdk/client/query.go
+++ b/sdk/client/query.go
@@ -57,7 +57,7 @@ func (sdkClient *SdkClient) QueryIsBlockBabylonFinalized(
 	if err != nil {
 		return false, err
 	}
-	if earliestDelHeight == 0 || btcblockHeight < earliestDelHeight {
+	if earliestDelHeight == math.MaxUint64 || btcblockHeight < earliestDelHeight {
 		return false, ErrBtcStakingNotActivated
 	}
 
@@ -161,7 +161,7 @@ func (sdkClient *SdkClient) QueryBtcStakingActivatedTimestamp() (uint64, error) 
 	}
 
 	// not activated yet
-	if earliestDelHeight == 0 {
+	if earliestDelHeight == math.MaxUint64 {
 		return math.MaxUint64, ErrBtcStakingNotActivated
 	}
 

--- a/sdk/client/query_test.go
+++ b/sdk/client/query_test.go
@@ -165,17 +165,17 @@ func TestQueryIsBlockBabylonFinalized(t *testing.T) {
 			if tc.name == "FP no delegation, 100% votes, expects false" {
 				mockBBNClient.EXPECT().
 					QueryEarliestActiveDelBtcHeight(tc.allFpPks).
-					Return(nil, nil).
+					Return(uint64(0), nil).
 					Times(1)
 			} else if tc.name == "Btc staking not activated, 100% votes, expects false" {
 				mockBBNClient.EXPECT().
 					QueryEarliestActiveDelBtcHeight(tc.allFpPks).
-					Return(&BTCNotActivatedHeight, nil).
+					Return(BTCNotActivatedHeight, nil).
 					Times(1)
 			} else {
 				mockBBNClient.EXPECT().
 					QueryEarliestActiveDelBtcHeight(tc.allFpPks).
-					Return(&BTCActivatedHeight, nil).
+					Return(BTCActivatedHeight, nil).
 					Times(1)
 			}
 
@@ -252,6 +252,7 @@ func TestQueryBlockRangeBabylonFinalized(t *testing.T) {
 			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockF.BlockTimestamp).Return(uint64(113), nil).AnyTimes()
 			mockBTCClient.EXPECT().GetBlockHeightByTimestamp(blockG.BlockTimestamp).Return(uint64(113), fmt.Errorf("RPC rate limit error")).AnyTimes()
 
+			mockBBNClient.EXPECT().QueryEarliestActiveDelBtcHeight(gomock.Any()).Return(uint64(1), nil).AnyTimes()
 			mockBBNClient.EXPECT().QueryAllFpBtcPubKeys("consumer-chain-id").Return([]string{"pk1", "pk2", "pk3"}, nil).AnyTimes()
 			mockBBNClient.EXPECT().QueryMultiFpPower([]string{"pk1", "pk2", "pk3"}, gomock.Any()).Return(map[string]uint64{"pk1": 100, "pk2": 200, "pk3": 300}, nil).AnyTimes()
 

--- a/sdk/client/query_test.go
+++ b/sdk/client/query_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/babylonchain/babylon-finality-gadget/sdk/cwclient"
+	"github.com/babylonchain/babylon-finality-gadget/testutil"
 	"github.com/babylonchain/babylon-finality-gadget/testutil/mocks"
-	"github.com/babylonchain/babylon-finality-gadget/testutils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -196,13 +196,13 @@ func TestQueryBlockRangeBabylonFinalized(t *testing.T) {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	l2BlockTime := uint64(2)
-	blockA, blockAWithHashTrimmed := testutils.RandomL2Block(rng)
-	blockB, blockBWithHashTrimmed := testutils.GenL2Block(rng, &blockA, l2BlockTime, 1)
-	blockC, blockCWithHashTrimmed := testutils.GenL2Block(rng, &blockB, l2BlockTime, 1)
-	blockD, blockDWithHashTrimmed := testutils.GenL2Block(rng, &blockC, l2BlockTime, 300) // 10 minutes later
-	blockE, blockEWithHashTrimmed := testutils.GenL2Block(rng, &blockD, l2BlockTime, 1)
-	blockF, blockFWithHashTrimmed := testutils.GenL2Block(rng, &blockE, l2BlockTime, 300)
-	blockG, blockGWithHashTrimmed := testutils.GenL2Block(rng, &blockF, l2BlockTime, 1)
+	blockA, blockAWithHashTrimmed := testutil.RandomL2Block(rng)
+	blockB, blockBWithHashTrimmed := testutil.GenL2Block(rng, &blockA, l2BlockTime, 1)
+	blockC, blockCWithHashTrimmed := testutil.GenL2Block(rng, &blockB, l2BlockTime, 1)
+	blockD, blockDWithHashTrimmed := testutil.GenL2Block(rng, &blockC, l2BlockTime, 300) // 10 minutes later
+	blockE, blockEWithHashTrimmed := testutil.GenL2Block(rng, &blockD, l2BlockTime, 1)
+	blockF, blockFWithHashTrimmed := testutil.GenL2Block(rng, &blockE, l2BlockTime, 300)
+	blockG, blockGWithHashTrimmed := testutil.GenL2Block(rng, &blockF, l2BlockTime, 1)
 
 	testCases := []struct {
 		name         string

--- a/testutil/mock_btc_client.go
+++ b/testutil/mock_btc_client.go
@@ -1,4 +1,4 @@
-package testutils
+package testutil
 
 import (
 	"github.com/babylonchain/babylon-finality-gadget/sdk/btcclient"

--- a/testutil/mocks/expected_clients_mock.go
+++ b/testutil/mocks/expected_clients_mock.go
@@ -57,10 +57,10 @@ func (mr *MockIBabylonClientMockRecorder) QueryAllFpBtcPubKeys(consumerId any) *
 }
 
 // QueryEarliestActiveDelBtcHeight mocks base method.
-func (m *MockIBabylonClient) QueryEarliestActiveDelBtcHeight(fpPubkeyHexList []string) (*uint64, error) {
+func (m *MockIBabylonClient) QueryEarliestActiveDelBtcHeight(fpPubkeyHexList []string) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueryEarliestActiveDelBtcHeight", fpPubkeyHexList)
-	ret0, _ := ret[0].(*uint64)
+	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -182,6 +182,21 @@ func (m *MockIBitcoinClient) GetBlockHeightByTimestamp(targetTimestamp uint64) (
 func (mr *MockIBitcoinClientMockRecorder) GetBlockHeightByTimestamp(targetTimestamp any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockHeightByTimestamp", reflect.TypeOf((*MockIBitcoinClient)(nil).GetBlockHeightByTimestamp), targetTimestamp)
+}
+
+// GetBlockTimestampByHeight mocks base method.
+func (m *MockIBitcoinClient) GetBlockTimestampByHeight(height uint64) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockTimestampByHeight", height)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockTimestampByHeight indicates an expected call of GetBlockTimestampByHeight.
+func (mr *MockIBitcoinClientMockRecorder) GetBlockTimestampByHeight(height any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockTimestampByHeight", reflect.TypeOf((*MockIBitcoinClient)(nil).GetBlockTimestampByHeight), height)
 }
 
 // MockICosmWasmClient is a mock of ICosmWasmClient interface.

--- a/testutil/mocks/sdkclient_mock.go
+++ b/testutil/mocks/sdkclient_mock.go
@@ -54,19 +54,19 @@ func (mr *MockISdkClientMockRecorder) QueryBlockRangeBabylonFinalized(queryBlock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryBlockRangeBabylonFinalized", reflect.TypeOf((*MockISdkClient)(nil).QueryBlockRangeBabylonFinalized), queryBlocks)
 }
 
-// QueryEarliestDelHeight mocks base method.
-func (m *MockISdkClient) QueryEarliestDelHeight() (*uint64, error) {
+// QueryBtcStakingActivatedTimestamp mocks base method.
+func (m *MockISdkClient) QueryBtcStakingActivatedTimestamp() (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryEarliestDelHeight")
-	ret0, _ := ret[0].(*uint64)
+	ret := m.ctrl.Call(m, "QueryBtcStakingActivatedTimestamp")
+	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// QueryEarliestDelHeight indicates an expected call of QueryEarliestDelHeight.
-func (mr *MockISdkClientMockRecorder) QueryEarliestDelHeight() *gomock.Call {
+// QueryBtcStakingActivatedTimestamp indicates an expected call of QueryBtcStakingActivatedTimestamp.
+func (mr *MockISdkClientMockRecorder) QueryBtcStakingActivatedTimestamp() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryEarliestDelHeight", reflect.TypeOf((*MockISdkClient)(nil).QueryEarliestDelHeight))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryBtcStakingActivatedTimestamp", reflect.TypeOf((*MockISdkClient)(nil).QueryBtcStakingActivatedTimestamp))
 }
 
 // QueryIsBlockBabylonFinalized mocks base method.

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -1,4 +1,4 @@
-package testutils
+package testutil
 
 import (
 	"math/rand"

--- a/testutils/mock_btc_client.go
+++ b/testutils/mock_btc_client.go
@@ -26,3 +26,9 @@ func (c *MockBtcClient) GetBlockHeightByTimestamp(targetTimestamp uint64) (uint6
 	// if it's too large, it will result in unbounding of the delegation
 	return 10, nil
 }
+
+// this is used to determine when the BTC staking is activated. return 0 to
+// simulate that the BTC staking is always activated
+func (c *MockBtcClient) GetBlockTimestampByHeight(height uint64) (uint64, error) {
+	return 0, nil
+}


### PR DESCRIPTION
## Summary

https://github.com/babylonchain/babylon-finality-gadget/issues/59

changed `QueryEarliestDelHeight` => `QueryBtcStakingActivatedTimestamp` to avoid doing the L2->BTC block conversion

it's better to return timestamp

---

also fixed broken test

## Test Plan

```
make mock-gen
make lint
make test
```

## Next Step
modify the OP code to use the query to only check quorum when BTC staking is activated. also remove the check for no voting power